### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project comprises three parts:
 The `tomorun` executable produces a histogram of a figure of merit under the
 distribution relevant for a reliable error analysis as described in [Faist &
 Renner, Practical and Reliable Error Bars in Quantum Tomography, Phys. Rev.
-Lett. 117, 010404 (2016)](http://dx.doi.org/10.1103/PhysRevLett.117.010404)
+Lett. 117, 010404 (2016)](https://doi.org/10.1103/PhysRevLett.117.010404)
 ([arXiv:1509.06763](http://arxiv.org/abs/1509.06763)).  The python interface
 provides an interface to the essentially the same functionality as `tomorun`
 from python/numpy code (plus the possibility for calculating a custom figure

--- a/doc/doxdocs/page_params.cxx
+++ b/doc/doxdocs/page_params.cxx
@@ -167,12 +167,12 @@
  *
  * 2. Br&uuml;ning et al., &ldquo;Parametrizations of density matrices,&rdquo; Journal of
  *    Modern Optics 59:1 1 (2012), <a
- *    href="http://dx.doi.org/10.1080/09500340.2011.632097">doi:10.1080/09500340.2011.632097</a>,
+ *    href="https://doi.org/10.1080/09500340.2011.632097">doi:10.1080/09500340.2011.632097</a>,
  *    <a href="http://arxiv.org/abs/1103.4542">arXiv:1103.4542</a>;
  *
  * 3. Bertlmann &amp; Krammer, &ldquo;Bloch vectors for qudits,&rdquo; Journal of Physics
  *    A 41:23 235303 (2008) <a
- *    href="http://dx.doi.org/10.1088/1751-8113/41/23/235303">doi:10.1088/1751-8113/41/23/235303</a>,
+ *    href="https://doi.org/10.1088/1751-8113/41/23/235303">doi:10.1088/1751-8113/41/23/235303</a>,
  *    <a href="http://arxiv.org/abs/0806.1174">arXiv:0806.1174</a>.
  *
  */

--- a/doc/doxdocs/page_theory.cxx
+++ b/doc/doxdocs/page_theory.cxx
@@ -86,7 +86,7 @@
 
 /** \page pageTheoryBinningAnalysis Binning Analysis
  *
- * Reference: [Ambegaokar, Troyer, Am. J. Phys. (2010), http://dx.doi.org/10.1119/1.3247985
+ * Reference: [Ambegaokar, Troyer, Am. J. Phys. (2010), https://doi.org/10.1119/1.3247985
  *             http://arxiv.org/abs/0906.0943]
  *
  * The Binning Analysis provides a powerful way of determining error bars for integrals

--- a/examples/two-qubits-Bell/README.md
+++ b/examples/two-qubits-Bell/README.md
@@ -2,7 +2,7 @@
 # Two-qubit example for `tomorun` usage
 
 Here is the two-qubit example presented in Section 5 of the supplemental material to
-https://dx.doi.org/10.1103/PhysRevLett.117.010404 .
+https://doi.org/10.1103/PhysRevLett.117.010404 .
 
 ## Running the example (with `tomorun` and MATLAB)
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links.

Cheers!